### PR TITLE
add endpoint for movies by year

### DIFF
--- a/movie-services/movie-services/movies_api/index.ts
+++ b/movie-services/movie-services/movies_api/index.ts
@@ -51,6 +51,12 @@ app.get('/movies/:movieId', (req: Request, res: Response) => {
   movies.getMovie(moviesDB, req, res)
 });
 
+//AC 3
+app.get('/movies/year/:year', (req: Request, res: Response) => {
+  movies.getMoviesByYear(moviesDB, req, res);
+});
+
+
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);
 });

--- a/movie-services/movie-services/movies_api/routes/movies.ts
+++ b/movie-services/movie-services/movies_api/routes/movies.ts
@@ -41,6 +41,43 @@ export const getAllMovies = (db: Database, req: Request, res: Response): void =>
   });
 };
 
+//ac 3
+export const getMoviesByYear = (db: Database, req: Request, res: Response): void => {
+  const year = req.params.year;
+  const page = parseInt(req.query.page as string) || 1;
+  const order = req.query.order === 'desc' ? 'DESC' : 'ASC';
+  const limit = 50;
+  const offset = (page - 1) * limit;
+
+  const query = `
+    SELECT imdbId, title, genres, release_date, budget
+    FROM movies
+    WHERE strftime('%Y', release_date) = ?
+    ORDER BY release_date ${order}
+    LIMIT ? OFFSET ?;
+  `;
+
+  db.all(query, [year, limit, offset], (err: Error | null, rows: any[]) => {
+    if (err) {
+      res.status(500).send(JSON.stringify(err));
+      return;
+    }
+
+    if (rows.length === 0) {
+      res.status(404).send('No movies found for the specified year');
+      return;
+    }
+
+    const formattedRows = rows.map(row => ({
+      ...row,
+      budget: `$${parseInt(row.budget).toLocaleString()}`
+    }));
+
+    res.send(formattedRows);
+  });
+};
+
+
 
 export const getMovie = (db: Database, req: Request, res: Response): void => {
   const query = 'SELECT * FROM movies WHERE movieId = ?';


### PR DESCRIPTION
#### Movies By Year
AC:

* An endpoint exists that will list all movies from a particular year
* List is paginated: 50 movies per page, the page can be altered with the `page` query params
* List is sorted by date in chronological order
* Sort order can be descending
* Columns include: imdb id, title, genres, release date, budget